### PR TITLE
fix: make sticker button not active on mobile

### DIFF
--- a/components/navbar/NavbarSimple.tsx
+++ b/components/navbar/NavbarSimple.tsx
@@ -24,14 +24,14 @@ export default function NavbarSimple() {
           <a href={`/#sticker`}>
             <Button
               variant="contained"
-              className="invisible lg:visible"
+              className="hidden lg:flex"
               size="btn-md"
             >
               Get a sticker
             </Button>
           </a>
 
-          <DrawerTrigger id="my-drawer" className="lg:hidden">
+          <DrawerTrigger id="my-drawer" className="cursor-pointer lg:hidden">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               className="h-5 w-5"


### PR DESCRIPTION
### Description

Fix so get sticker button in nav doesnt work at all on collapse. earlier was still triggering.
Also add cursor pointer to drawer butotn